### PR TITLE
Add Open Street/Cycle Map in grayscale (fixes #53)

### DIFF
--- a/enhydris_openhigis/static/js/TileLayer.Grayscale.js
+++ b/enhydris_openhigis/static/js/TileLayer.Grayscale.js
@@ -1,0 +1,56 @@
+/*
+ * L.TileLayer.Grayscale is a regular tilelayer with grayscale makeover.
+ */
+
+L.TileLayer.Grayscale = L.TileLayer.extend({
+	options: {
+		quotaRed: 21,
+		quotaGreen: 71,
+		quotaBlue: 8,
+		quotaDividerTune: 0,
+		quotaDivider: function() {
+			return this.quotaRed + this.quotaGreen + this.quotaBlue + this.quotaDividerTune;
+		}
+	},
+
+	initialize: function (url, options) {
+		options = options || {}
+		options.crossOrigin = true;
+		L.TileLayer.prototype.initialize.call(this, url, options);
+
+		this.on('tileload', function(e) {
+			this._makeGrayscale(e.tile);
+		});
+	},
+
+	_createTile: function () {
+		var tile = L.TileLayer.prototype._createTile.call(this);
+		tile.crossOrigin = "Anonymous";
+		return tile;
+	},
+
+	_makeGrayscale: function (img) {
+		if (img.getAttribute('data-grayscaled'))
+			return;
+
+                img.crossOrigin = '';
+		var canvas = document.createElement("canvas");
+		canvas.width = img.width;
+		canvas.height = img.height;
+		var ctx = canvas.getContext("2d");
+		ctx.drawImage(img, 0, 0);
+
+		var imgd = ctx.getImageData(0, 0, canvas.width, canvas.height);
+		var pix = imgd.data;
+		for (var i = 0, n = pix.length; i < n; i += 4) {
+                        pix[i] = pix[i + 1] = pix[i + 2] = (this.options.quotaRed * pix[i] + this.options.quotaGreen * pix[i + 1] + this.options.quotaBlue * pix[i + 2]) / this.options.quotaDivider();
+		}
+		ctx.putImageData(imgd, 0, 0);
+		img.setAttribute('data-grayscaled', true);
+		img.src = canvas.toDataURL();
+	}
+});
+
+L.tileLayer.grayscale = function (url, options) {
+	return new L.TileLayer.Grayscale(url, options);
+};

--- a/enhydris_openhigis/static/js/enhydris-openhigis-map.js
+++ b/enhydris_openhigis/static/js/enhydris-openhigis-map.js
@@ -27,10 +27,10 @@ openhigis.map.setUpBaseLayers = function() {
 };
 
 openhigis.map.setUpOverlayLayers = function() {
-    this.addOpenhiLayer("RiverBasins", "Λεκάνες απορροής");
-    this.addOpenhiLayer("StationBasins", "Λεκάνες ανάντη σταθμών");
-    this.addOpenhiLayer("Watercourses", "Ποτάμια");
-    this.addOpenhiLayer("StandingWaters", "Λίμνες");
+    this.addOpenhiLayer("RiverBasins", "Λεκάνες απορροής", true);
+    this.addOpenhiLayer("StationBasins", "Λεκάνες ανάντη σταθμών", false);
+    this.addOpenhiLayer("Watercourses", "Ποτάμια", true);
+    this.addOpenhiLayer("StandingWaters", "Λίμνες", true);
 };
 
 /* This is a replacement for BetterWMS's getFeatureInfoUrl() which adds the
@@ -64,7 +64,7 @@ openhigis.map.getFeatureInfoUrl = function (latlng) {
     return this._url + L.Util.getParamString(params, this._url, true);
 };
 
-openhigis.map.addOpenhiLayer = function(name, legend) {
+openhigis.map.addOpenhiLayer = function(name, legend, initiallyVisible) {
     var layer = L.tileLayer.betterWms(openhigis.ows_url, {
         layers: name,
         format: "image/png",
@@ -72,6 +72,9 @@ openhigis.map.addOpenhiLayer = function(name, legend) {
     });
     layer.getFeatureInfoUrl = openhigis.map.getFeatureInfoUrl;
     this.layersControl.addOverlay(layer, legend);
+    if (initiallyVisible) {
+      layer.addTo(this);
+    };
 };
 
 openhigis.map.setUp();

--- a/enhydris_openhigis/templates/enhydris_openhigis/base/default.html
+++ b/enhydris_openhigis/templates/enhydris_openhigis/base/default.html
@@ -1,5 +1,10 @@
-{% extends "enhydris/base/main.html" %}
+{% extends "enhydris/base/main_with_map.html" %}
 {% load static %}
+
+
+{% block body_onload %}
+{% endblock %}
+
 
 {% block basecss %}
   {{ block.super }}
@@ -8,18 +13,72 @@
   />
 {% endblock %}
 
-{% block mainjs %}
+
+{% block leaflet_plugins %}
   {{ block.super }}
-  <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.5.1/leaflet.js"></script>
-  <script src="{% static "js/L.Control.MousePosition.js"%}"></script>
-  {% block map_js %}
-    <script type="text/javascript">
-      {{ map_js | safe }}
-      var openhigis = {
-          ows_url: "{{ ows_url }}"
-      };
-    </script>
-  {% endblock %}
+  <script type="text/javascript" src="{% static "js/TileLayer.Grayscale.js" %}"></script>
+{% endblock %}
+
+
+{% block map_js %}
+  <script type="text/javascript">
+    enhydris.mapBaseLayers = {
+      "Open Street Map": L.tileLayer(
+        "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        {
+          attribution: (
+            'Map data © <a href="https://www.openstreetmap.org/">' +
+            'OpenStreetMap</a> contributors, ' +
+            '<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>'
+          ),
+          maxZoom: 18,
+        }
+      ),
+      "Open Cycle Map": L.tileLayer(
+        "https://{s}.tile.thunderforest.com/cycle/{z}/{x}/{y}.png?apikey=6ee1510f01024952802dd06a65660b00",
+        {
+          attribution: (
+            'Map data © <a href="https://www.openstreetmap.org/">' +
+            'OpenStreetMap</a> contributors, ' +
+            '<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>'
+          ),
+          maxZoom: 18,
+        }
+      ),
+      "Open Street Map Grayscale": L.tileLayer.grayscale(
+        "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        {
+          attribution: (
+            'Map data © <a href="https://www.openstreetmap.org/">' +
+            'OpenStreetMap</a> contributors, ' +
+            '<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>'
+          ),
+          maxZoom: 18,
+        }
+      ),
+      "Open Cycle Map Grayscale": L.tileLayer.grayscale(
+        "https://{s}.tile.thunderforest.com/cycle/{z}/{x}/{y}.png?apikey=6ee1510f01024952802dd06a65660b00", {
+          attribution: (
+            'Map data © <a href="https://www.openstreetmap.org/">' +
+            'OpenStreetMap</a> contributors, ' +
+            '<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>'
+          ),
+          maxZoom: 18,
+        }
+      )
+    };
+    enhydris.mapDefaultBaseLayer = "Open Cycle Map Grayscale";
+    enhydris.mapViewport = {{ map_viewport|safe }};
+    enhydris.mapMarkers = {{ map_markers|safe }};
+    enhydris.searchString = {{ searchString|safe }};
+    var openhigis = {
+        ows_url: "{{ ows_url }}"
+    };
+  </script>
+{% endblock %}
+
+
+{% block extrajs %}
   <script type="text/javascript" src="{% static "js/betterwms.js" %}">
   </script>
   <script type="text/javascript" src="{% static "js/enhydris-openhigis-map.js" %}">


### PR DESCRIPTION
This hardwires the layers in the code (not using
ENHYDRIS_MAP_BASE_LAYERS any more); sets Open Cycle Map grayscale as
initially visible; and sets some data layers as initially visible.