### PR TITLE
Make cosmetic changes to the map (fixes #57)

### DIFF
--- a/enhydris_openhigis/static/css/enhydris-openhigis.css
+++ b/enhydris_openhigis/static/css/enhydris-openhigis.css
@@ -17,3 +17,8 @@
 #openhigis-map.leaflet-grab:not(.leaflet-drag-target) {
     cursor: default;  /* Cursor is used both for grabbing and selecting */
 }
+
+#openhigis-map.leaflet-container {
+    background: white;
+    border: 2px solid lightgray;
+}

--- a/enhydris_openhigis/static/js/enhydris-openhigis-map.js
+++ b/enhydris_openhigis/static/js/enhydris-openhigis-map.js
@@ -27,10 +27,12 @@ openhigis.map.setUpBaseLayers = function() {
 };
 
 openhigis.map.setUpOverlayLayers = function() {
-    this.addOpenhiLayer("RiverBasins", "Λεκάνες απορροής", true);
-    this.addOpenhiLayer("StationBasins", "Λεκάνες ανάντη σταθμών", false);
-    this.addOpenhiLayer("Watercourses", "Ποτάμια", true);
-    this.addOpenhiLayer("StandingWaters", "Λίμνες", true);
+    this.addOpenhiLayer("Watercourses", "Υδρογραφικό δίκτυο", "#33CCFF", "□", true);
+    this.addOpenhiLayer("StandingWaters", "Λίμνες", "#33CCFF", "■", true);
+    this.addOpenhiLayer(
+        "StationBasins", "Λεκάνες ανάντη σταθμών", "#0066FF", "▮", false
+    );
+    this.addOpenhiLayer("RiverBasins", "Λεκάνες απορροής", "#0066FF", "▮", true);
 };
 
 /* This is a replacement for BetterWMS's getFeatureInfoUrl() which adds the
@@ -64,13 +66,17 @@ openhigis.map.getFeatureInfoUrl = function (latlng) {
     return this._url + L.Util.getParamString(params, this._url, true);
 };
 
-openhigis.map.addOpenhiLayer = function(name, legend, initiallyVisible) {
+openhigis.map.addOpenhiLayer = function(
+    name, legendText, legendSymbolColor, legendSymbol, initiallyVisible
+) {
     var layer = L.tileLayer.betterWms(openhigis.ows_url, {
         layers: name,
         format: "image/png",
         transparent: true,
     });
     layer.getFeatureInfoUrl = openhigis.map.getFeatureInfoUrl;
+    var legend = '<span style="color: ' + legendSymbolColor + '; font-size: large">'
+        + legendSymbol + '</span> ' + legendText;
     this.layersControl.addOverlay(layer, legend);
     if (initiallyVisible) {
       layer.addTo(this);

--- a/enhydris_openhigis/templates/enhydris_openhigis/base/default.html
+++ b/enhydris_openhigis/templates/enhydris_openhigis/base/default.html
@@ -65,7 +65,18 @@
           ),
           maxZoom: 18,
         }
-      )
+      ),
+      "Εθνικό Κτηματολόγιο": L.tileLayer.wms(
+        "http://gis.ktimanet.gr/wms/wmsopen/wmsserver.aspx",
+        {
+          layers: "KTBASEMAP",
+          format: "image/png",
+          attribution: (
+            "Χαρτογραφικά δεδομένα © Εθνικό Κτηματολόγιο & Χαρτογράφηση Α.Ε."
+          ),
+        },
+      ),
+      "Χωρίς υπόβαθρο": L.tileLayer(""),
     };
     enhydris.mapDefaultBaseLayer = "Open Cycle Map Grayscale";
     enhydris.mapViewport = {{ map_viewport|safe }};

--- a/mapserver/openhigis.map
+++ b/mapserver/openhigis.map
@@ -225,7 +225,7 @@ MAP
             STYLE
                 OUTLINECOLOR 51 204 255
                 OPACITY 100
-                WIDTH 1
+                WIDTH [streamorder]
             END
         END
     END


### PR DESCRIPTION
Several improvements:
- The items in the layer selection are reordered
- A colored symbol has been added to the layer selector, as legend
- The thickness of watercourses depends on the order
- Blank background and National Cadastre background has been added